### PR TITLE
fix compatible issue between Alibaba hg submission and official tf release

### DIFF
--- a/closed/Alibaba/code/resnet/tfcpp/classification_and_detection/cpp/CMakeLists.txt
+++ b/closed/Alibaba/code/resnet/tfcpp/classification_and_detection/cpp/CMakeLists.txt
@@ -7,12 +7,14 @@ if(NOT LG_PATH)
   message( FATAL_ERROR "LG_PATH is not defined" )
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mavx2 -msse2 -msse4 -D_GLIBCXX_USE_CXX11_ABI=0")
+
 add_subdirectory(${LG_PATH} loadgen)
 
 find_package(OpenCV REQUIRED)
 set(TF_PATH $ENV{TF_PATH})
-set(CMAKE_CXX_FLAGS "-Wl,--no-undefined -fPIC -std=c++11 -fopenmp -D_GLIBCXX_USE_CXX11_ABI=1")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mavx2 -msse2 -msse4")
+set(CMAKE_CXX_FLAGS "-Wl,--no-undefined -fPIC -std=c++11 -fopenmp -D_GLIBCXX_USE_CXX11_ABI=0")
 execute_process(COMMAND bash "-c" "${PROJECT_SOURCE_DIR}/tf_version.sh" OUTPUT_VARIABLE TF_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND bash "-c" "${PROJECT_SOURCE_DIR}/python_site.sh" OUTPUT_VARIABLE PYTHON_SITE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/closed/Alibaba/measurements/alibaba_HanGuang/resnet/MultiStream/README.md
+++ b/closed/Alibaba/measurements/alibaba_HanGuang/resnet/MultiStream/README.md
@@ -44,7 +44,7 @@ Click [here](https://github.com/tensorflow/tensorflow/archive/v1.13.1.tar.gz) to
    ```shell
    cd tensorflow-1.13.1
    ./configure
-   bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma //tensorflow/tools/pip_package:build_pip_package
+   bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma --copt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow/tools/pip_package:build_pip_package
    bazel-bin/tensorflow/tools/pip_package/build_pip_package ../
    pip install ../tensorflow-1.13.1-cp35-cp35m-linux_x86_64.whl
    ```
@@ -52,7 +52,7 @@ Click [here](https://github.com/tensorflow/tensorflow/archive/v1.13.1.tar.gz) to
 #### Build Tensorflow CC
 
    ```shell
-   $ bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma //tensorflow:libtensorflow_cc.so
+   $ bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma --copt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow:libtensorflow_cc.so
    ```
 
 ### MLPerf Inference

--- a/closed/Alibaba/measurements/alibaba_HanGuang/resnet/Offline/README.md
+++ b/closed/Alibaba/measurements/alibaba_HanGuang/resnet/Offline/README.md
@@ -44,7 +44,7 @@ Click [here](https://github.com/tensorflow/tensorflow/archive/v1.13.1.tar.gz) to
    ```shell
    cd tensorflow-1.13.1
    ./configure
-   bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma //tensorflow/tools/pip_package:build_pip_package
+   bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma --copt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow/tools/pip_package:build_pip_package
    bazel-bin/tensorflow/tools/pip_package/build_pip_package ../
    pip install ../tensorflow-1.13.1-cp35-cp35m-linux_x86_64.whl
    ```
@@ -52,7 +52,7 @@ Click [here](https://github.com/tensorflow/tensorflow/archive/v1.13.1.tar.gz) to
 #### Build Tensorflow CC
 
    ```shell
-   $ bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma //tensorflow:libtensorflow_cc.so
+   $ bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma --copt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow:libtensorflow_cc.so
    ```
 
 ### MLPerf Inference

--- a/closed/Alibaba/measurements/alibaba_HanGuang/resnet/Server/README.md
+++ b/closed/Alibaba/measurements/alibaba_HanGuang/resnet/Server/README.md
@@ -44,7 +44,7 @@ Click [here](https://github.com/tensorflow/tensorflow/archive/v1.13.1.tar.gz) to
    ```shell
    cd tensorflow-1.13.1
    ./configure
-   bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma //tensorflow/tools/pip_package:build_pip_package
+   bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma --copt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow/tools/pip_package:build_pip_package
    bazel-bin/tensorflow/tools/pip_package/build_pip_package ../
    pip install ../tensorflow-1.13.1-cp35-cp35m-linux_x86_64.whl
    ```
@@ -52,7 +52,7 @@ Click [here](https://github.com/tensorflow/tensorflow/archive/v1.13.1.tar.gz) to
 #### Build Tensorflow CC
 
    ```shell
-   $ bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma //tensorflow:libtensorflow_cc.so
+   $ bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma --copt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow:libtensorflow_cc.so
    ```
 
 ### MLPerf Inference

--- a/closed/Alibaba/measurements/alibaba_HanGuang/resnet/SingleStream/README.md
+++ b/closed/Alibaba/measurements/alibaba_HanGuang/resnet/SingleStream/README.md
@@ -44,7 +44,7 @@ Click [here](https://github.com/tensorflow/tensorflow/archive/v1.13.1.tar.gz) to
    ```shell
    cd tensorflow-1.13.1
    ./configure
-   bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma //tensorflow/tools/pip_package:build_pip_package
+   bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma --copt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow/tools/pip_package:build_pip_package
    bazel-bin/tensorflow/tools/pip_package/build_pip_package ../
    pip install ../tensorflow-1.13.1-cp35-cp35m-linux_x86_64.whl
    ```
@@ -52,7 +52,7 @@ Click [here](https://github.com/tensorflow/tensorflow/archive/v1.13.1.tar.gz) to
 #### Build Tensorflow CC
 
    ```shell
-   $ bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma //tensorflow:libtensorflow_cc.so
+   $ bazel build -c opt --copt=-msse4.2 --copt=-mavx2 --copt=-mfma --copt=-D_GLIBCXX_USE_CXX11_ABI=0 //tensorflow:libtensorflow_cc.so
    ```
 
 ### MLPerf Inference


### PR DESCRIPTION
as gcc 5 is the default gcc for ubuntu 16.04, compile flag -D_GLIBCXX_USE_CXX11_ABI=0 is needed to make Alibaba HanGuang implementation compatible with official tensorflow release installed through pip.

submission result are not affected by this change.